### PR TITLE
Fix/use_frameworks_podfile_bug

### DIFF
--- a/AppLovin MAX Demo App - Swift/Podfile
+++ b/AppLovin MAX Demo App - Swift/Podfile
@@ -1,4 +1,3 @@
-use_frameworks!
 inhibit_all_warnings!
 
 target 'AppLovin MAX Demo App - Swift' do


### PR DESCRIPTION
@shane-tang found an interesting bug with our Swift demo app (bug not present in Obj-C demo app), seems related to how we started distributing our SDK as an `xcframework` in 10.3.0. Not sure exactly what causes it though. Had a similar fix in the email thread: `Unity 4.3.0 Upgrade`, but in a different context. @christophercong any insight on what exactly about using frameworks instead of static libraries causes this crash?

```
unrecognized selector sent to class 0x7fff863c67e0
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '+[NSDate al_timeIntervalNow]
```
