### PR TITLE
Override Verve HyBid SDK user consent if not assigned beforehand

### DIFF
--- a/Verve/VerveAdapter/ALVerveMediationAdapter.m
+++ b/Verve/VerveAdapter/ALVerveMediationAdapter.m
@@ -216,7 +216,11 @@ static MAAdapterInitializationStatus ALVerveInitializationStatus = NSIntegerMin;
         NSNumber *hasUserConsent = parameters.hasUserConsent;
         if ( hasUserConsent )
         {
-            [[HyBidUserDataManager sharedInstance] setIABGDPRConsentString: hasUserConsent.boolValue ? @"1" : @"0"];
+            NSString* verveGDPRConsentString = [[HyBidUserDataManager sharedInstance] getIABGDPRConsentString];
+            if ( !verveGDPRConsentString || [verveGDPRConsentString isEqualToString:@""] )
+            {
+                [[HyBidUserDataManager sharedInstance] setIABGDPRConsentString: hasUserConsent.boolValue ? @"1" : @"0"];
+            }
         }
         else { /* Don't do anything if huc value not set */ }
     }
@@ -229,14 +233,19 @@ static MAAdapterInitializationStatus ALVerveInitializationStatus = NSIntegerMin;
     
     if ( ALSdk.versionCode >= 61100 )
     {
-        NSNumber *isDoNotSell = parameters.doNotSell;
-        if ( isDoNotSell && isDoNotSell.boolValue )
+        NSString* verveUSPrivacyString = [[HyBidUserDataManager sharedInstance] getIABUSPrivacyString];
+        
+        if ( !verveUSPrivacyString || [verveUSPrivacyString isEqualToString:@""] )
         {
-            [[HyBidUserDataManager sharedInstance] setIABUSPrivacyString: @"1NYN"];
-        }
-        else
-        {
-            [[HyBidUserDataManager sharedInstance] removeIABUSPrivacyString];
+            NSNumber *isDoNotSell = parameters.doNotSell;
+            if ( isDoNotSell && isDoNotSell.boolValue )
+            {
+                [[HyBidUserDataManager sharedInstance] setIABUSPrivacyString: @"1NYN"];
+            }
+            else
+            {
+                [[HyBidUserDataManager sharedInstance] removeIABUSPrivacyString];
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request contains the following changes:

- Check for existing GDPR consent string before overriding the value on HyBid's UserDataManager
- Check for existing CCPA consent string before overriding the value on HyBid's UserDataManager

We have reviewed other adapters and they don't include this type of override code. HyBid SDK is TCF compliant, therefore if there's any change in the consent via a CMP, it will reflect on HyBid automatically. If the publisher doesn't use a TCF CMP then there won't be any consent string fetched by HyBid, so it will accept the one passed in the adapter.