### PR TITLE
Migrated verizon adapter to yahoo mobile sdk

### DIFF
--- a/VerizonAds/AppLovinMediationVerizonAdsAdapter.podspec
+++ b/VerizonAds/AppLovinMediationVerizonAdsAdapter.podspec
@@ -29,7 +29,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.framework"
 
-s.dependency 'Verizon-Ads-StandardEdition', '= 1.14.2'
+s.dependency 'Yahoo-Mobile-SDK', '1.0.0-beta1'
 s.dependency 'AppLovinSDK'
 
 s.pod_target_xcconfig =


### PR DESCRIPTION
Preview of what is needed to use Yahoo Mobile SDK which is a replacement for Verizon Ads and will be released shortly.

The 1.0.0-beta1 version of YahooMobileSDK can be fetched using the pod hosted on `source 'https://github.com/flurry/Yahoo-Mobile-SDK.git'`

This is the iOS equivalent of https://github.com/AppLovin/AppLovin-MAX-SDK-Android/pull/287.