### PR TITLE
fix/fix_late_binding_native_ads_memory_leak

### DIFF
--- a/AppLovin MAX Demo App - ObjC/AppLovin MAX Demo App - ObjC/MAX/Native Ads/ALMAXManualNativeLateBindingAdViewController.m
+++ b/AppLovin MAX Demo App - ObjC/AppLovin MAX Demo App - ObjC/MAX/Native Ads/ALMAXManualNativeLateBindingAdViewController.m
@@ -90,6 +90,15 @@
     [self.nativeAdLoader renderNativeAdView: self.nativeAdView withAd: self.nativeAd];
     [self.nativeAdContainerView addSubview: self.nativeAdView];
     
+    // Set to false if modifying constraints after adding the ad view to your layout
+    self.nativeAdContainerView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    // Set ad view to span width and height of container and center the ad
+    [self.nativeAdContainerView.widthAnchor constraintEqualToAnchor: self.nativeAdView.widthAnchor].active = YES;
+    [self.nativeAdContainerView.heightAnchor constraintEqualToAnchor: self.nativeAdView.heightAnchor].active = YES;
+    [self.nativeAdContainerView.centerXAnchor constraintEqualToAnchor: self.nativeAdView.centerXAnchor].active = YES;
+    [self.nativeAdContainerView.centerYAnchor constraintEqualToAnchor: self.nativeAdView.centerYAnchor].active = YES;
+    
     [self.showAdButton setEnabled: NO];
 }
 
@@ -103,15 +112,6 @@
     self.nativeAd = ad;
     
     [self.showAdButton setEnabled: YES];
-    
-    // Set to false if modifying constraints after adding the ad view to your layout
-    self.nativeAdContainerView.translatesAutoresizingMaskIntoConstraints = NO;
-    
-    // Set ad view to span width and height of container and center the ad
-    [self.nativeAdContainerView.widthAnchor constraintEqualToAnchor: nativeAdView.widthAnchor].active = YES;
-    [self.nativeAdContainerView.heightAnchor constraintEqualToAnchor: nativeAdView.heightAnchor].active = YES;
-    [self.nativeAdContainerView.centerXAnchor constraintEqualToAnchor: nativeAdView.centerXAnchor].active = YES;
-    [self.nativeAdContainerView.centerYAnchor constraintEqualToAnchor: nativeAdView.centerYAnchor].active = YES;
 }
 
 - (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error

--- a/AppLovin MAX Demo App - Swift/AppLovin MAX Demo App - Swift/MAX/Native Ads/ALMAXManualNativeLateBindingAdViewController.swift
+++ b/AppLovin MAX Demo App - Swift/AppLovin MAX Demo App - Swift/MAX/Native Ads/ALMAXManualNativeLateBindingAdViewController.swift
@@ -88,6 +88,15 @@ class ALMAXManualNativeLateBindingAdViewController: ALBaseAdViewController
             nativeAdLoader.renderNativeAdView(nativeAdView, with: nativeAd)
             nativeAdContainerView.addSubview(nativeAdView)
             
+            // Set to false if modifying constraints after adding the ad view to your layout
+            nativeAdContainerView.translatesAutoresizingMaskIntoConstraints = false
+            
+            // Set ad view to span width and height of container and center the ad
+            nativeAdContainerView.widthAnchor.constraint(equalTo: nativeAdView.widthAnchor).isActive = true
+            nativeAdContainerView.heightAnchor.constraint(equalTo: nativeAdView.heightAnchor).isActive = true
+            nativeAdContainerView.centerXAnchor.constraint(equalTo: nativeAdView.centerXAnchor).isActive = true
+            nativeAdContainerView.centerYAnchor.constraint(equalTo: nativeAdView.centerYAnchor).isActive = true
+            
             showAdButton.isEnabled = false
         }
     }
@@ -103,18 +112,6 @@ extension ALMAXManualNativeLateBindingAdViewController: MANativeAdDelegate
         nativeAd = ad
         
         showAdButton.isEnabled = true
-        
-        if let adView = maxNativeAdView
-        {
-            // Set to false if modifying constraints after adding the ad view to your layout
-            adView.translatesAutoresizingMaskIntoConstraints = false
-            
-            // Set ad view to span width and height of container and center the ad
-            nativeAdContainerView.widthAnchor.constraint(equalTo: adView.widthAnchor).isActive = true
-            nativeAdContainerView.heightAnchor.constraint(equalTo: adView.heightAnchor).isActive = true
-            nativeAdContainerView.centerXAnchor.constraint(equalTo: adView.centerXAnchor).isActive = true
-            nativeAdContainerView.centerYAnchor.constraint(equalTo: adView.centerYAnchor).isActive = true
-        }
     }
     
     func didFailToLoadNativeAd(forAdUnitIdentifier adUnitIdentifier: String, withError error: MAError)


### PR DESCRIPTION
Found during investigating this issue: https://github.com/AppLovin/AppLovin-MAX-SDK-iOS/issues/110
After that issue is solved, found deinit is still not being called in Manual Late Binding Native ads in swift repo.

Retain cycle not found this time, but moving the anchor setting code segment after adding NativeAdView to container solved this leak.

Objective-c repo was working, only make changes to keep consistency with swift repo.