### PR TITLE
HyprMX Adapter - Update SDK Init to provide Consent Status, mediator info, update display error callbacks

### DIFF
--- a/HyprMX/HyprMXAdapter/ALHyprMXMediationAdapter.m
+++ b/HyprMX/HyprMXAdapter/ALHyprMXMediationAdapter.m
@@ -501,12 +501,15 @@ static NSString *const kHyprMXRandomUserIdKey = @"com.applovin.sdk.mediation.ran
     [self.delegate didHideInterstitialAd];
 }
 
-- (void)adDisplayErrorForPlacement:(HyprMXPlacement *)placement error:(HyprMXError)hyprMXError
+-(void)adDisplayError:(NSError *)error placement:(HyprMXPlacement *)placement
 {
-    [self.parentAdapter log: @"Interstitial failed to display with error: %d for placement: %@", hyprMXError, placement.placementName];
+    [self.parentAdapter log: @"Interstitial failed to display with error: %d for placement: %@", error.localizedDescription, placement.placementName];
+    MAAdapterError *adapterError = [MAAdapterError errorWithCode:-4205
+                                                     errorString:@"Ad Display Failed"
+                                        mediatedNetworkErrorCode:error.code
+                                     mediatedNetworkErrorMessage:error.localizedDescription];
+    [self.delegate didFailToDisplayInterstitialAdWithError:adapterError];
     
-    MAAdapterError *adapterError = [MAAdapterError errorWithCode: -4205 errorString: @"Ad Display Failed" thirdPartySdkErrorCode: hyprMXError thirdPartySdkErrorMessage: @""];
-    [self.delegate didFailToDisplayInterstitialAdWithError: adapterError];
 }
 
 @end
@@ -565,12 +568,15 @@ static NSString *const kHyprMXRandomUserIdKey = @"com.applovin.sdk.mediation.ran
     [self.delegate didHideRewardedAd];
 }
 
-- (void)adDisplayErrorForPlacement:(HyprMXPlacement *)placement error:(HyprMXError)hyprMXError
+-(void)adDisplayError:(NSError *)error placement:(HyprMXPlacement *)placement
 {
-    [self.parentAdapter log: @"Rewarded ad failed to display with error: %d, for placement: %@", hyprMXError, placement.placementName];
+    [self.parentAdapter log: @"Interstitial failed to display with error: %d for placement: %@", error.localizedDescription, placement.placementName];
+    MAAdapterError *adapterError = [MAAdapterError errorWithCode:-4205
+                                                     errorString:@"Ad Display Failed"
+                                        mediatedNetworkErrorCode:error.code
+                                     mediatedNetworkErrorMessage:error.localizedDescription];
+    [self.delegate didFailToDisplayRewardedAdWithError:adapterError];
     
-    MAAdapterError *adapterError = [MAAdapterError errorWithCode: -4205 errorString: @"Ad Display Failed" thirdPartySdkErrorCode: hyprMXError thirdPartySdkErrorMessage: @""];
-    [self.delegate didFailToDisplayRewardedAdWithError: adapterError];
 }
 
 - (void)adDidRewardForPlacement:(HyprMXPlacement *)placement rewardName:(NSString *)rewardName rewardValue:(NSInteger)rewardValue

--- a/HyprMX/HyprMXAdapter/ALHyprMXMediationAdapter.m
+++ b/HyprMX/HyprMXAdapter/ALHyprMXMediationAdapter.m
@@ -110,9 +110,13 @@ static NSString *const kHyprMXRandomUserIdKey = @"com.applovin.sdk.mediation.ran
         
         self.initializationDelegate = [[ALHyprMXMediationAdapterInitializationDelegate alloc] initWithParentAdapter: self completionHandler: completionHandler];
         
+        [HyprMX setMediationProvider:HyprMXMediationProviderApplovinMax
+                  mediatorSDKVersion:[ALSdk version]
+                      adapterVersion:[self adapterVersion]];
         // NOTE: HyprMX deals with CCPA via their UI
         [HyprMX initializeWithDistributorId: distributorId
                                      userId: userId
+                              consentStatus: [self consentValueForParams:parameters]
                      initializationDelegate: self.initializationDelegate];
     }
     else
@@ -262,15 +266,17 @@ static NSString *const kHyprMXRandomUserIdKey = @"com.applovin.sdk.mediation.ran
 - (void)updateConsentWithParameters:(id<MAAdapterParameters>)parameters
 {
     // NOTE: HyprMX requested to always set GDPR regardless of region.
+    [HyprMX setConsentStatus: [self consentValueForParams:parameters]];
+}
+
+-(HyprConsentStatus)consentValueForParams:(id<MAAdapterParameters>)parameters
+{
     NSNumber *hasUserConsent = parameters.hasUserConsent;
     if ( hasUserConsent )
     {
-        [HyprMX setConsentStatus: hasUserConsent.boolValue ? CONSENT_GIVEN : CONSENT_DECLINED];
+        return hasUserConsent.boolValue ? CONSENT_GIVEN : CONSENT_DECLINED;
     }
-    else
-    {
-        [HyprMX setConsentStatus: CONSENT_STATUS_UNKNOWN];
-    }
+    return CONSENT_STATUS_UNKNOWN;
 }
 
 #pragma mark - Helper Methods


### PR DESCRIPTION
- Updates SDK Initialization to use `[HyprMX initializeWithDistributorId:userId:consentStatus:initializationDelegate:]` to provide consent status at SDK Init
- Sets Mediator info for support diagnostics
- Updates to newer Ad Display callback `[HyprMXPlacementDelegate adDisplayError:placement:]`.  Also updated `MAAdapterError` with `mediatedNetworkErrorCode` and  `mediatedNetworkErrorMessage`