### PR TITLE
HyBid 2.16.0: Include swift headers in the import. 

### DIFF
--- a/Verve/AppLovinMediationVerveAdapter.podspec
+++ b/Verve/AppLovinMediationVerveAdapter.podspec
@@ -29,7 +29,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'HyBid', '= 2.16.0-beta1'
+s.dependency 'HyBid', '= 2.16.0'
 s.dependency 'AppLovinSDK'
 
 s.pod_target_xcconfig =

--- a/Verve/AppLovinMediationVerveAdapter.podspec
+++ b/Verve/AppLovinMediationVerveAdapter.podspec
@@ -29,7 +29,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'HyBid', '= 2.14.0'
+s.dependency 'HyBid', '= 2.16.0-beta1'
 s.dependency 'AppLovinSDK'
 
 s.pod_target_xcconfig =

--- a/Verve/VerveAdapter/ALVerveMediationAdapter.m
+++ b/Verve/VerveAdapter/ALVerveMediationAdapter.m
@@ -15,7 +15,6 @@
 
 #define ADAPTER_VERSION @"2.14.0.0"
 
-
 @interface ALVerveMediationAdapterInterstitialAdDelegate : NSObject<HyBidInterstitialAdDelegate>
 @property (nonatomic, weak) ALVerveMediationAdapter *parentAdapter;
 @property (nonatomic, strong) id<MAInterstitialAdapterDelegate> delegate;

--- a/Verve/VerveAdapter/ALVerveMediationAdapter.m
+++ b/Verve/VerveAdapter/ALVerveMediationAdapter.m
@@ -7,13 +7,14 @@
 //
 
 #import "ALVerveMediationAdapter.h"
+#import <HyBid/HyBid.h>
 #if __has_include(<HyBid/HyBid-Swift.h>)
     #import <HyBid/HyBid-Swift.h>
 #else
     #import "HyBid-Swift.h"
 #endif
 
-#define ADAPTER_VERSION @"2.15.0.0"
+#define ADAPTER_VERSION @"2.16.0.0"
 
 @interface ALVerveMediationAdapterInterstitialAdDelegate : NSObject<HyBidInterstitialAdDelegate>
 @property (nonatomic, weak) ALVerveMediationAdapter *parentAdapter;

--- a/Verve/VerveAdapter/ALVerveMediationAdapter.m
+++ b/Verve/VerveAdapter/ALVerveMediationAdapter.m
@@ -7,9 +7,14 @@
 //
 
 #import "ALVerveMediationAdapter.h"
-#import <HyBid.h>
+#if __has_include(<HyBid/HyBid-Swift.h>)
+    #import <HyBid/HyBid-Swift.h>
+#else
+    #import "HyBid-Swift.h"
+#endif
 
 #define ADAPTER_VERSION @"2.14.0.0"
+
 
 @interface ALVerveMediationAdapterInterstitialAdDelegate : NSObject<HyBidInterstitialAdDelegate>
 @property (nonatomic, weak) ALVerveMediationAdapter *parentAdapter;


### PR DESCRIPTION
We just released HyBid 2.16.0. This version included swift files in the project, therefore the mediation adapter should include the swift headers in order to compile those files. 

from:
`import <HyBid.h>`

to:
```
#import <HyBid/HyBid.h>
#if __has_include(<HyBid/HyBid-Swift.h>)
    #import <HyBid/HyBid-Swift.h>
#else
    #import "HyBid-Swift.h"
#endif
```

