### PR TITLE
[Unity Ads 4.8.0] Adding usage of bannerDidShow callback to report impressions

### DIFF
--- a/UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m
+++ b/UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m
@@ -617,6 +617,12 @@ static MAAdapterInitializationStatus ALUnityAdsInitializationStatus = NSIntegerM
     [self.parentAdapter log: @"Banner ad left application"];
 }
 
+- (void)bannerViewDidShow:(UADSBannerView *)bannerView
+{
+    [self.parentAdapter log: @"Banner showed"];
+    [self.delegate didDisplayAdViewAd];
+}
+
 @end
 
 @implementation ALUnityAdsInitializationDelegate


### PR DESCRIPTION
### Description
In Unity Ads 4.8.0, we are adding a new bannerViewDidShow callback to our banner listener to more accurately report impressions.

### How
Added bannerViewDidShow to the adapter and calling didDisplayAdViewAd method