### PR TITLE
Update initialization check in Vungle adapter init (#16)

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -113,7 +113,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     [self updateUserPrivacySettingsForParameters: parameters];
     
-    if ( [ALVungleInitialized compareAndSet: NO update: YES] )
+    if ( ![ALVungleInitialized get] && ALVungleIntializationStatus != MAAdapterInitializationStatusInitializing )
     {
         ALVungleIntializationStatus = MAAdapterInitializationStatusInitializing;
         
@@ -134,7 +134,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             else
             {
                 [self log: @"Vungle SDK initialized"];
-                
+                [ALVungleInitialized compareAndSet: NO update: YES];
                 ALVungleIntializationStatus = MAAdapterInitializationStatusInitializedSuccess;
                 completionHandler(ALVungleIntializationStatus, nil);
             }


### PR DESCRIPTION
Fixed initialization check in Vungle adapter to allow retries on SDK init failures, improving reliability of ad loading and playback.