### PR TITLE
Create GitHub workflow to close stale issues

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -1,0 +1,22 @@
+name: Stale and close inactive issues
+on:
+  schedule:
+    - cron: "0 1 * * *"
+    
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 250
+          exempt-issue-labels: "in progress"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-stale: 30
+          days-before-issue-close: 5
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 5 days since being marked as stale."


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Create a GitHub workflow to automatically mark issues as stale and close them if they remain inactive.

### Why are these changes being made?
This change is being made to manage the backlog of issues by identifying and closing inactive issues, ensuring that the project's issue tracker remains relevant and actionable. This automated process helps maintain a clean and organized development workflow by dealing with issues that have not been updated or interacted with over a set period.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->