### PR TITLE
IronSource/update_changelog

### DIFF
--- a/IronSource/CHANGELOG.md
+++ b/IronSource/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.5.0.0.0
 * Certified with IronSource SDK 8.5.0.0.
+* Updated minimum Xcode requirement to 15.3.
 * Removed redundant log output when initialization was already completed.
 
 ## 8.4.0.0.0


### PR DESCRIPTION
Update the changelog to indicate that IronSource adapter version 8.5.0.0.0 requires minimum Xcode v15.3.