### PR TITLE
[FIX] BidMachine default clickable assets for native ads

### DIFF
--- a/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
+++ b/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
@@ -1148,6 +1148,7 @@ static MAAdapterInitializationStatus ALBidMachineSDKInitializationStatus = NSInt
     {
         MABidMachineNativeAdRendering *adRendering = [[MABidMachineNativeAdRendering alloc] initWithNativeAdView: container];
         self.parentAdapter.nativeAd.controller = [ALUtils topViewControllerFromKeyWindow];
+        [self.parentAdapter.nativeAd registerDefaultAssetsForInteraction];
         [self.parentAdapter.nativeAd presentAd: container : adRendering error: &error];
     }
     // Plugins


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a call to `registerDefaultAssetsForInteraction` for native ads in `ALBidMachineMediationAdapter.m`.

### Why are these changes being made?

These changes ensure that the default clickable assets are properly registered, improving user interaction accuracy with the native ads. This adjustment rectifies an oversight and enhances the reliability of ad interactions in the BidMachine mediation adapter.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->