### PR TITLE
Pubmatic adapter v4.2.0.1

### DIFF
--- a/PubMatic/AppLovinMediationPubMaticAdapter.podspec
+++ b/PubMatic/AppLovinMediationPubMaticAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationPubMaticAdapter'
-s.version = '4.1.0.0'
+s.version = '4.2.0.0'
 s.platform = :ios, '12.0'
 s.summary = 'PubMatic adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.0.0
+* Certified with PubMatic SDK 4.2.0.
+* Updated PubMatic SDK adapter to use bidder specific APIs to load banner, interstitial and rewarded ads.
+
 ## 4.1.0.0
 * Certified with PubMatic SDK 4.1.0.
 * Removed exception throwing if unable to map ad format to that of the network's.

--- a/PubMatic/PubMaticAdapter/ALPubMaticMediationAdapter.m
+++ b/PubMatic/PubMaticAdapter/ALPubMaticMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALPubMaticMediationAdapter.h"
 #import <OpenWrapSDK/OpenWrapSDK.h>
 
-#define ADAPTER_VERSION @"4.1.0.0"
+#define ADAPTER_VERSION @"4.2.0.0"
 
 @interface ALPubMaticMediationAdapterInterstitialDelegate : NSObject <POBInterstitialDelegate>
 @property (nonatomic,   weak) ALPubMaticMediationAdapter *parentAdapter;
@@ -150,17 +150,13 @@ static MAAdapterInitializationStatus ALPubMaticInitializationStatus = NSIntegerM
 
 - (void)loadInterstitialAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAInterstitialAdapterDelegate>)delegate
 {
-    NSString *publisherId = [self publisherIdFromParameters: parameters];
-    NSNumber *profileId = [self profileIdFromParameters: parameters];
     NSString *adUnitId = [self adUnitIdFromParameters: parameters];
     
     [self log: @"Loading interstitial ad: %@...", adUnitId];
     
     self.interstitialAdDelegate = [[ALPubMaticMediationAdapterInterstitialDelegate alloc] initWithParentAdapter: self
                                                                                                       andNotify: delegate];
-    self.interstitialAd = [[POBInterstitial alloc] initWithPublisherId: publisherId
-                                                             profileId: profileId
-                                                              adUnitId: adUnitId];
+    self.interstitialAd = [[POBInterstitial alloc] init];
     self.interstitialAd.delegate = self.interstitialAdDelegate;
     
     [self.interstitialAd loadAdWithResponse: parameters.bidResponse];
@@ -188,17 +184,13 @@ static MAAdapterInitializationStatus ALPubMaticInitializationStatus = NSIntegerM
 
 - (void)loadRewardedAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate
 {
-    NSString *publisherId = [self publisherIdFromParameters: parameters];
-    NSNumber *profileId = [self profileIdFromParameters: parameters];
     NSString *adUnitId = [self adUnitIdFromParameters: parameters];
     
     [self log: @"Loading rewarded ad: %@...", adUnitId];
     
     self.rewardedAdDelegate = [[ALPubMaticMediationAdapterRewardedDelegate alloc] initWithParentAdapter: self
                                                                                               andNotify: delegate];
-    self.rewardedAd = [POBRewardedAd rewardedAdWithPublisherId: publisherId
-                                                     profileId: profileId
-                                                      adUnitId: adUnitId];
+    self.rewardedAd = [[POBRewardedAd alloc] init];
     self.rewardedAd.delegate = self.rewardedAdDelegate;
     
     [self.rewardedAd loadAdWithResponse: parameters.bidResponse];
@@ -230,20 +222,14 @@ static MAAdapterInitializationStatus ALPubMaticInitializationStatus = NSIntegerM
                          adFormat:(MAAdFormat *)adFormat
                         andNotify:(id<MAAdViewAdapterDelegate>)delegate
 {
-    NSString *publisherId = [self publisherIdFromParameters: parameters];
-    NSNumber *profileId = [self profileIdFromParameters: parameters];
     NSString *adUnitId = [self adUnitIdFromParameters: parameters];
-    POBAdSize *adSize = [self POBAdSizeFromAdFormat: adFormat];
     
     [self log: @"Loading %@ ad: %@...", adFormat.label, adUnitId];
     
     self.adViewDelegate = [[ALPubMaticMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
                                                                                            format: adFormat
                                                                                         andNotify: delegate];
-    self.adView = [[POBBannerView alloc] initWithPublisherId: publisherId
-                                                   profileId: profileId
-                                                    adUnitId: adUnitId
-                                                     adSizes: @[adSize]];
+    self.adView = [[POBBannerView alloc] init];
     self.adView.delegate = self.adViewDelegate;
     
     [self.adView loadAdWithResponse: parameters.bidResponse];


### PR DESCRIPTION
Hello team,

This PR contains -

1. Updated adapter to version 4.2.0.1
2. Update adapter to use Bidder specific APIs to load Banner, Interstitial, and Rewarded ads, as per the integration guide shared by PubMatic.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Update the PubMatic AppLovin mediation adapter to version 4.2.0.1, refactor the SDK adapter to leverage bidder-specific APIs by removing the usage of `publisherId` and `profileId` for loading ads, and update documentation to reflect these changes.

### Why are these changes being made? 

These changes aim to streamline the ad-loading process by utilizing bidder-specific APIs that improve efficiency and potentially enhance ad load times by removing redundant parameters such as `publisherId` and `profileId`. Additionally, version updates ensure compatibility and ensure that end users can leverage the latest features and improvements offered by the PubMatic SDK.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->