### PR TITLE
Update PubMatic Adapter to v4.4.0.1

### DIFF
--- a/PubMatic/AppLovinMediationPubMaticAdapter.podspec
+++ b/PubMatic/AppLovinMediationPubMaticAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationPubMaticAdapter'
-s.version = '4.4.0.0'
+s.version = '4.4.0.1'
 s.platform = :ios, '12.0'
 s.summary = 'PubMatic adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.0.1
+* Updated to support gpid (Global Placement ID).
+
 ## 4.4.0.0
 * Certified with PubMatic SDK 4.4.0.
 

--- a/PubMatic/PubMaticAdapter/ALPubMaticMediationAdapter.m
+++ b/PubMatic/PubMaticAdapter/ALPubMaticMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALPubMaticMediationAdapter.h"
 #import <OpenWrapSDK/OpenWrapSDK.h>
 
-#define ADAPTER_VERSION @"4.4.0.0"
+#define ADAPTER_VERSION @"4.4.0.1"
 
 @interface ALPubMaticMediationAdapterInterstitialDelegate : NSObject <POBInterstitialDelegate>
 @property (nonatomic,   weak) ALPubMaticMediationAdapter *parentAdapter;
@@ -139,6 +139,8 @@ static MAAdapterInitializationStatus ALPubMaticInitializationStatus = NSIntegerM
     }
     
     POBSignalConfig *signalConfig = [[POBSignalConfig alloc] initWithAdFormat: adFormat];
+    signalConfig.gpid = parameters.adUnitIdentifier;
+
     NSString *bidToken = [POBSignalGenerator generateSignalForBiddingHost: POBSDKBiddingHostALMAX
                                                                 andConfig: signalConfig];
     


### PR DESCRIPTION
# Description

Added support for sending GPID to PubMatic SDK

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the PubMatic Adapter to version 4.4.0.1 to support Global Placement ID (gpid).

### Why are these changes being made?

These changes are necessary to enhance the adapter's functionality by integrating support for the gpid feature, which allows for more precise ad placements. The version increment in the podspec file and the change in adapter version ensures consistent deployment and compatibility.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->