### PR TITLE
Yandex 7.12.1.1

### DIFF
--- a/Yandex/AppLovinMediationYandexAdapter.podspec
+++ b/Yandex/AppLovinMediationYandexAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationYandexAdapter'
-s.version = '7.12.0.0'
+s.version = '7.12.0.1'
 s.platform = :ios, '13.0'
 s.summary = 'Yandex adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/Yandex/CHANGELOG.md
+++ b/Yandex/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.12.0.1
+* Update to use new APIs for ad targeting
+
 ## 7.12.0.0
 * Certified with Yandex SDK 7.12.0.
 


### PR DESCRIPTION
Support ad targeting in BidderTokenRequestConfiguration

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the Yandex adapter for AppLovin mediation to version 7.12.0.1 with enhancements to support new APIs for ad targeting.

### Why are these changes being made?
These changes aim to improve the targeting capabilities of the Yandex adapter by utilizing additional user data such as age, gender, location, context query, and context tags to optimize ad delivery, ensuring compatibility with the latest Yandex SDK and providing users with more relevant ad experiences.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->