### PR TITLE
[ALBidMachineMediationAdapter] updated to BidMachine v3.3.0

### DIFF
--- a/BidMachine/AppLovinMediationBidMachineAdapter.podspec
+++ b/BidMachine/AppLovinMediationBidMachineAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationBidMachineAdapter'
-s.version = '3.2.1.0.0'
+s.version = '3.3.0.0.0'
 s.platform = :ios, '12.0'
 s.summary = 'BidMachine adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"


### PR DESCRIPTION
- BidMachine SDK version 3.3.0
- PlacementFormat moved to BidMachinePlacement
- deprecated BidMachineRequestInfoProtocol moved to BidMachineAuctionRequest

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the AppLovinMediationBidMachineAdapter to be compatible with BidMachine v3.3.0.

### Why are these changes being made?
This update aligns the adapter with BidMachine v3.3.0, introducing new method signatures and handling for placements and auction requests, improving compatibility and correctness in ad handling. This ensures the adapter can efficiently interface with the updated BidMachine SDK functions such as `placementFrom` and enhanced error management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->