### PR TITLE
UnityAds 4.15.0 getToken update

### DIFF
--- a/UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m
+++ b/UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m
@@ -122,7 +122,8 @@ static MAAdapterInitializationStatus ALUnityAdsInitializationStatus = NSIntegerM
     
     [self updatePrivacyConsent: parameters];
     
-    [UnityAds getToken:^(NSString *signal) {
+    UnityAdsTokenConfiguration *configuration = [UnityAdsTokenConfiguration newWithAdFormat: [self toUnityAdFormat:parameters.adFormat]];
+    [UnityAds getTokenWith: configuration completion: ^(NSString *signal) {
         [self log: @"Signal collected"];
         [delegate didCollectSignal: signal];
     }];
@@ -369,6 +370,19 @@ static MAAdapterInitializationStatus ALUnityAdsInitializationStatus = NSIntegerM
     return [MAAdapterError errorWithAdapterError: adapterError
                         mediatedNetworkErrorCode: unityAdsShowError
                      mediatedNetworkErrorMessage: message];
+}
+
+- (UnityAdsAdFormat)toUnityAdFormat:(MAAdFormat*)adFormat {
+    UnityAdsAdFormat format = UnityAdsAdFormatInterstitial;
+    if ( [adFormat isAdViewAd] )
+    {
+        format = UnityAdsAdFormatBanner;
+    }
+    else if ( adFormat == MAAdFormat.rewarded )
+    {
+        format = UnityAdsAdFormatRewarded;
+    }
+    return format;
 }
 
 #pragma mark - GDPR


### PR DESCRIPTION
* Gets MaxAdFormat from the MaxAdapterSignalCollectionParameters configuration
* Converts the MaxAdFormat from to Unity's AdFormat
* Pass the AdFormat to getToken call to optimize ad loading processes for faster ad delivery