### PR TITLE
Native ads Media content aspect Ratio

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1033,6 +1033,9 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self.parentAdapter log: @"Native %@ ad loaded: %@", self.adFormat, self.placementIdentifier];
     
+    // returns aspect ratio of media to be displayed. Will return 0.0 by default
+    CGFloat mediaContentAspectRatio = [nativeAd getMediaAspectRatio];
+    
     dispatchOnMainQueue(^{
         MediaView *mediaView = [[MediaView alloc] init];
         
@@ -1043,6 +1046,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             builder.callToAction = nativeAd.callToAction;
             builder.icon = [[MANativeAdImage alloc] initWithImage: nativeAd.iconImage];
             builder.mediaView = mediaView;
+            builder.mediaContentAspectRatio = mediaContentAspectRatio;
         }];
         
         // Backend will pass down `vertical` as the template to indicate using a vertical native template
@@ -1139,6 +1143,9 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self.parentAdapter log: @"Native ad loaded: %@", self.placementIdentifier];
     
+    // returns aspect ratio of media to be displayed. Will return 0.0 by default
+    CGFloat mediaContentAspectRatio = [nativeAd getMediaAspectRatio];
+    
     dispatchOnMainQueue(^{
         MediaView *mediaView = [[MediaView alloc] init];
         
@@ -1149,6 +1156,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             builder.callToAction = nativeAd.callToAction;
             builder.icon = [[MANativeAdImage alloc] initWithImage: nativeAd.iconImage];
             builder.mediaView = mediaView;
+            builder.mediaContentAspectRatio = mediaContentAspectRatio;
         }];
         
         NSString *creativeIdentifier = nativeAd.creativeId;


### PR DESCRIPTION
This commit will add aspect ratio of media content for native ads.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add handling for additional Vungle error cases and include media content aspect ratio for native ads.

### Why are these changes being made?

This change improves the robustness of error handling within the Vungle mediation adapter by mapping a wider variety of Vungle-specific errors to the appropriate MaxAds adapter errors. Additionally, retrieving and handling the media content aspect ratio enhances the formatting and display of native ads, ensuring they maintain the intended visual presentation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->