### PR TITLE
Fix build by raising minimum platform to 12.0

### DIFF
--- a/AppLovin MAX Demo App - ObjC/Podfile
+++ b/AppLovin MAX Demo App - ObjC/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 inhibit_all_warnings!
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 # Please use 'pod install --repo-update' to ensure you have the latest versions of our SDKs.
 

--- a/AppLovin MAX Demo App - Swift/Podfile
+++ b/AppLovin MAX Demo App - Swift/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 inhibit_all_warnings!
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 # Please use 'pod install --repo-update' to ensure you have the latest versions of our SDKs.
 


### PR DESCRIPTION
In 3def7db2 the code was updated to use Adjust SDK 5, but this broke the build. The demo app's Podfile declared a minimum iOS version of 11.0; Adjust SDK 5 requires iOS 12.0 or higher. CocoaPods continued to install Adjust 4, mismatching the code.

AppLovinSDK has required iOS 12.0 or higher since 13.2.0, so it's safe and appropriate to raise the minimum here to iOS 12, unblocking installation of Adjust 5.