### PR TITLE
Fix for wrong delegate callback methods

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1084,7 +1084,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     });
 }
 
-- (void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error
+- (void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error
 {
     MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
     [self.parentAdapter log: @"Native %@ ad failed to load with error: %@", self.adFormat, adapterError];
@@ -1169,7 +1169,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     });
 }
 
-- (void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error
+- (void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error
 {
     MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
     [self.parentAdapter log: @"Native ad failed to load with error: %@", adapterError];


### PR DESCRIPTION
This commit will fix the wrong delegate callback methods below.
In `ALVungleMediationAdapterNativeAdViewDelegate` and `ALVungleMediationAdapterNativeAdDelegate`,

`(void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error`
should be
`(void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error`