### PR TITLE
update ByteDance adapter 7904

### DIFF
--- a/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
+++ b/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
@@ -197,7 +197,17 @@ static MAAdapterInitializationStatus ALByteDanceInitializationStatus = NSInteger
     
     PAGBiddingRequest *request = [self createSignalRequestForAdFormat: parameters.adFormat withParameters: parameters];
     
-    [PAGSdk getBiddingTokenWithRequest: request completion:^(NSString *biddingToken) {
+    [PAGSdk getBiddingTokenWithRequest: request
+                     completionHandler: ^(NSString * _Nullable biddingToken, NSError * _Nullable error) {
+        
+        if ( error )
+        {
+            [self log: @"Signal collection failed with error: %@", error];
+            [delegate didFailToCollectSignalWithErrorMessage: error.description];
+            
+            return;
+        }
+        
         [self log: @"Signal collection successful"];
         [delegate didCollectSignal: biddingToken];
     }];
@@ -690,12 +700,6 @@ static MAAdapterInitializationStatus ALByteDanceInitializationStatus = NSInteger
 - (void)updateConsentWithParameters:(id<MAAdapterParameters>)parameters
 {
     PAGConfig *configuration = [PAGConfig shareConfig];
-    
-    NSNumber *hasUserConsent = parameters.hasUserConsent;
-    if ( hasUserConsent != nil )
-    {
-        configuration.PAConsent = hasUserConsent.boolValue ? PAGPAConsentTypeConsent : PAGPAConsentTypeNoConsent;
-    }
     
     NSNumber *isDoNotSell = parameters.isDoNotSell;
     if ( isDoNotSell != nil )

--- a/ByteDance/CHANGELOG.md
+++ b/ByteDance/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## 7.9.0.4.0
 * Certified with ByteDance SDK 7.9.0.4.
+* Manual configuration of GDPR information is no longer supported. Pangle will automatically read the settings from the CMP.
 
 ## 7.8.5.8.0
 * Certified with ByteDance SDK 7.8.5.8.


### PR DESCRIPTION
1. Manual configuration of GDPR information is no longer supported. Pangle will automatically read the settings from the CMP.
2. Enhanced error handling with the new `getBiddingToken` API.