### PR TITLE
Update Yandex adapter to SDK 8 + AppOpenAd

### DIFF
--- a/Yandex/YandexAdapter/ALYandexMediationAdapter.h
+++ b/Yandex/YandexAdapter/ALYandexMediationAdapter.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ALYandexMediationAdapter : ALMediationAdapter <MASignalProvider, MAInterstitialAdapter, MARewardedAdapter, MAAdViewAdapter, MANativeAdAdapter>
+@interface ALYandexMediationAdapter : ALMediationAdapter <MASignalProvider, MAInterstitialAdapter, MARewardedAdapter, MAAdViewAdapter, MANativeAdAdapter, MAAppOpenAdapter>
 
 @end
 

--- a/Yandex/YandexAdapter/ALYandexMediationAdapter.m
+++ b/Yandex/YandexAdapter/ALYandexMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALYandexMediationAdapter.h"
 #import <YandexMobileAds/YandexMobileAds.h>
 
-#define ADAPTER_VERSION @"7.18.4.0"
+#define ADAPTER_VERSION @"8.0.0.0-beta"
 
 #define TITLE_LABEL_TAG          1
 #define MEDIA_VIEW_CONTAINER_TAG 2
@@ -21,7 +21,7 @@
 /**
  * Dedicated delegate object for Yandex interstitial ads.
  */
-@interface ALYandexMediationAdapterInterstitialAdDelegate : NSObject <YMAInterstitialAdLoaderDelegate, YMAInterstitialAdDelegate>
+@interface ALYandexMediationAdapterInterstitialAdDelegate : NSObject <YMAInterstitialAdDelegate>
 
 @property (nonatomic,   weak) ALYandexMediationAdapter *parentAdapter;
 @property (nonatomic, strong) id<MAAdapterResponseParameters> parameters;
@@ -34,7 +34,7 @@
 /**
  * Dedicated delegate object for Yandex rewarded ads.
  */
-@interface ALYandexMediationAdapterRewardedAdDelegate : NSObject <YMARewardedAdLoaderDelegate, YMARewardedAdDelegate>
+@interface ALYandexMediationAdapterRewardedAdDelegate : NSObject <YMARewardedAdDelegate>
 
 @property (nonatomic,   weak) ALYandexMediationAdapter *parentAdapter;
 @property (nonatomic, strong) id<MAAdapterResponseParameters> parameters;
@@ -46,9 +46,9 @@
 @end
 
 /**
- * Dedicated delegate object for Yandex AdView ads.
+ * Dedicated delegate object for Yandex BannerAdView ads.
  */
-@interface ALYandexMediationAdapterAdViewDelegate : NSObject <YMAAdViewDelegate>
+@interface ALYandexMediationAdapterAdViewDelegate : NSObject <YMABannerAdViewDelegate>
 
 @property (nonatomic,   weak) ALYandexMediationAdapter *parentAdapter;
 @property (nonatomic,   weak) NSString *adFormatLabel;
@@ -63,7 +63,7 @@
 /**
  * Dedicated delegate object for Yandex Native ads.
  */
-@interface ALYandexMediationAdapterNativeAdDelegate : NSObject <YMANativeAdDelegate, YMANativeAdLoaderDelegate>
+@interface ALYandexMediationAdapterNativeAdDelegate : NSObject <YMANativeAdDelegate>
 
 @property (nonatomic,   weak) ALYandexMediationAdapter *parentAdapter;
 @property (nonatomic, strong) id<MAAdapterResponseParameters> parameters;
@@ -98,7 +98,7 @@
 @property (nonatomic, strong) YMARewardedAdLoader *rewardedAdLoader;
 
 // AdView
-@property (nonatomic, strong) YMAAdView *adView;
+@property (nonatomic, strong) YMABannerAdView *adView;
 @property (nonatomic, strong) ALYandexMediationAdapterAdViewDelegate *adViewAdapterDelegate;
 
 // Native
@@ -116,14 +116,19 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
 {
     [super initialize];
     
-    ALYandexBidderTokenLoader = [[YMABidderTokenLoader alloc] initWithMediationNetworkName: @"applovin"];
+    ALYandexBidderTokenLoader = [[YMABidderTokenLoader alloc] init];
+    
+    YMAAdapterIdentity *adapterIdentity = [[YMAAdapterIdentity alloc] initWithAdapterNetworkName: @"applovin"
+                                                                                  adapterVersion: ADAPTER_VERSION
+                                                                           adapterNetworkVersion: ALSdk.version];
+    [YMAYandexAds setAdapterIdentity: adapterIdentity];
 }
 
 #pragma mark - MAAdapter Methods
 
 - (NSString *)SDKVersion
 {
-    return [YMAMobileAds sdkVersion];
+    return [YMAYandexAds sdkVersion].stringValue;
 }
 
 - (NSString *)adapterVersion
@@ -139,7 +144,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     
     if ( [parameters isTesting] )
     {
-        [YMAMobileAds enableLogging];
+        [YMAYandexAds enableLogging];
     }
     
     completionHandler(MAAdapterInitializationStatusDoesNotApply, nil);
@@ -151,14 +156,12 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.interstitialAd = nil;
     self.interstitialAdapterDelegate.delegate = nil;
     self.interstitialAdapterDelegate = nil;
-    self.interstitialAdLoader.delegate = nil;
     self.interstitialAdLoader = nil;
     
     self.rewardedAd.delegate = nil;
     self.rewardedAd = nil;
     self.rewardedAdapterDelegate.delegate = nil;
     self.rewardedAdapterDelegate = nil;
-    self.rewardedAdLoader.delegate = nil;
     self.rewardedAdLoader = nil;
     
     self.adView.delegate = nil;
@@ -170,7 +173,6 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.nativeAd = nil;
     self.nativeAdapterDelegate.delegate = nil;
     self.nativeAdapterDelegate = nil;
-    self.nativeAdLoader.delegate = nil;
     self.nativeAdLoader = nil;
 }
 
@@ -180,8 +182,8 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
 {
     [self log: @"Collecting signal..."];
     
-    YMAAdType yandexAdType = [self toYandexAdType: parameters.adFormat];
-    if ( yandexAdType == -1 )
+    YMABidderTokenRequest *request = [self toBidderTokenRequest: parameters.adFormat parameters: parameters];
+    if ( !request )
     {
         [self log: @"Signal collection failed with error: Unsupported ad format: %@", parameters.adFormat];
         [delegate didFailToCollectSignalWithErrorMessage: [NSString stringWithFormat: @"Unsupported ad format: %@", parameters.adFormat]];
@@ -189,24 +191,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
         return;
     }
     
-    YMABidderTokenRequestConfiguration *configuration = [[YMABidderTokenRequestConfiguration alloc] initWithAdType: yandexAdType];
-    
-    if (yandexAdType == YMAAdTypeBanner)
-    {
-        BOOL isAdaptiveAdViewEnabled = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
-        if ( isAdaptiveAdViewEnabled && ALSdk.versionCode < 13020099 )
-        {
-            [self userError: @"Please update AppLovin MAX SDK to version 13.2.0 or higher in order to use Yandex adaptive ads"];
-            isAdaptiveAdViewEnabled = NO;
-        }
-        
-        YMABannerAdSize *adSize = [self yandexAdSizeFromAdFormat: parameters.adFormat
-                                         isAdaptiveAdViewEnabled: isAdaptiveAdViewEnabled
-                                                      parameters: parameters];
-        configuration.bannerAdSize = adSize;
-    }
-    
-    [ALYandexBidderTokenLoader loadBidderTokenWithRequestConfiguration: configuration completionHandler:^(NSString *bidderToken) {
+    [ALYandexBidderTokenLoader loadBidderTokenWithRequest: request completionHandler:^(NSString *bidderToken) {
         [self log: @"Collected signal"];
         [delegate didCollectSignal: bidderToken];
     }];
@@ -225,10 +210,27 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.interstitialAdapterDelegate = [[ALYandexMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self
                                                                                                       withParameters: parameters
                                                                                                            andNotify: delegate];
-    self.interstitialAdLoader.delegate = self.interstitialAdapterDelegate;
     
-    YMAMutableAdRequestConfiguration *configuration = [self createAdRequestConfigurationForPlacementId: placementId parameters: parameters];
-    [self.interstitialAdLoader loadAdWithRequestConfiguration: configuration];
+    YMAAdRequest *adRequest = [self createAdRequestForPlacementId: placementId parameters: parameters];
+    
+    __weak typeof(self) weakSelf = self;
+    [self.interstitialAdLoader loadAdWith: adRequest completionHandler:^(YMAInterstitialAd * _Nullable interstitialAd, NSError * _Nullable error) {
+        __strong typeof(self) strongSelf = weakSelf;
+        if ( !strongSelf ) return;
+        
+        if ( error )
+        {
+            [strongSelf log: @"Interstitial ad failed to load with error code %ld and description: %@", error.code, error.description];
+            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+            [strongSelf.interstitialAdapterDelegate.delegate didFailToLoadInterstitialAdWithError: adapterError];
+            return;
+        }
+        
+        [strongSelf log: @"Interstitial ad loaded"];
+        strongSelf.interstitialAd = interstitialAd;
+        interstitialAd.delegate = strongSelf.interstitialAdapterDelegate;
+        [strongSelf.interstitialAdapterDelegate.delegate didLoadInterstitialAd];
+    }];
 }
 
 - (void)showInterstitialAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAInterstitialAdapterDelegate>)delegate
@@ -272,10 +274,27 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.rewardedAdapterDelegate = [[ALYandexMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self
                                                                                               withParameters: parameters
                                                                                                    andNotify: delegate];
-    self.rewardedAdLoader.delegate = self.rewardedAdapterDelegate;
     
-    YMAMutableAdRequestConfiguration *configuration = [self createAdRequestConfigurationForPlacementId: placementId parameters: parameters];
-    [self.rewardedAdLoader loadAdWithRequestConfiguration: configuration];
+    YMAAdRequest *adRequest = [self createAdRequestForPlacementId: placementId parameters: parameters];
+    
+    __weak typeof(self) weakSelf = self;
+    [self.rewardedAdLoader loadAdWith: adRequest completionHandler:^(YMARewardedAd * _Nullable rewardedAd, NSError * _Nullable error) {
+        __strong typeof(self) strongSelf = weakSelf;
+        if ( !strongSelf ) return;
+        
+        if ( error )
+        {
+            [strongSelf log: @"Rewarded ad failed to load with error code %ld and description: %@", error.code, error.description];
+            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+            [strongSelf.rewardedAdapterDelegate.delegate didFailToLoadRewardedAdWithError: adapterError];
+            return;
+        }
+        
+        [strongSelf log: @"Rewarded ad loaded"];
+        strongSelf.rewardedAd = rewardedAd;
+        rewardedAd.delegate = strongSelf.rewardedAdapterDelegate;
+        [strongSelf.rewardedAdapterDelegate.delegate didLoadRewardedAd];
+    }];
 }
 
 - (void)showRewardedAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate
@@ -333,9 +352,11 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
                                                   parameters: parameters];
     
     // NOTE: iOS banner ads do not auto-refresh by default
-    self.adView = [[YMAAdView alloc] initWithAdUnitID: placementId adSize: adSize];
+    self.adView = [[YMABannerAdView alloc] initWithAdSize: adSize];
     self.adView.delegate = self.adViewAdapterDelegate;
-    [self.adView loadAdWithRequest: [self createAdRequestWithParameters: parameters]];
+
+    YMAAdRequest *adRequest = [self createAdRequestForPlacementId: placementId parameters: parameters];
+    [self.adView loadAdWithRequest: adRequest];
 }
 
 #pragma mark - MANativeAdAdapter Methods
@@ -351,11 +372,41 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.nativeAdapterDelegate = [[ALYandexMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
                                                                                           withParameters: parameters
                                                                                                andNotify: delegate];
-    self.nativeAdLoader.delegate = self.nativeAdapterDelegate;
     
-    YMAMutableNativeAdRequestConfiguration *config = [self createNativeAdRequestConfigurationForPlacementId: placementId
-                                                                                                 parameters: parameters];
-    [self.nativeAdLoader loadAdWithRequestConfiguration: config];
+    YMAAdRequest *adRequest = [self createAdRequestForPlacementId: placementId parameters: parameters];
+    
+    __weak typeof(self) weakSelf = self;
+    [self.nativeAdLoader loadAdWith: adRequest options: [[YMANativeAdOptions alloc] initWithShouldLoadImagesAutomatically:YES] completionHandler:^(id<YMANativeAd> _Nullable nativeAd, NSError * _Nullable error) {
+        __strong typeof(self) strongSelf = weakSelf;
+        if ( !strongSelf ) return;
+        
+        if ( error )
+        {
+            [strongSelf log: @"Native ad failed to load with error code %ld and description: %@", error.code, error.description];
+            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+            [strongSelf.nativeAdapterDelegate.delegate didFailToLoadNativeAdWithError: adapterError];
+            return;
+        }
+        
+        [strongSelf log: @"Native ad loaded"];
+        strongSelf.nativeAd = nativeAd;
+        nativeAd.delegate = strongSelf.nativeAdapterDelegate;
+        YMANativeAdAssets *assets = [nativeAd adAssets];
+        MANativeAd *maxNativeAd = [[MAYandexNativeAd alloc] initWithParentAdapter: strongSelf builderBlock:^(MANativeAdBuilder *builder) {
+            builder.title = assets.title;
+            builder.advertiser = assets.domain;
+            builder.body = assets.body;
+            builder.callToAction = assets.callToAction;
+            builder.icon = [[MANativeAdImage alloc] initWithImage: assets.icon.imageValue];
+            builder.mainImage = [[MANativeAdImage alloc] initWithImage: assets.image.imageValue];
+            builder.optionsView = [[UIButton alloc] init];
+            builder.mediaView = [[YMANativeMediaView alloc] init];
+            builder.mediaContentAspectRatio = assets.media.aspectRatio;
+            builder.starRating = assets.rating;
+        }];
+        
+        [strongSelf.nativeAdapterDelegate.delegate didLoadAdForNativeAd: maxNativeAd withExtraInfo: nil];
+    }];
 }
 
 #pragma mark - Helper Methods
@@ -365,56 +416,23 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     NSNumber *hasUserConsent = [parameters hasUserConsent];
     if ( hasUserConsent != nil )
     {
-        [YMAMobileAds setUserConsent: hasUserConsent.boolValue];
+        [YMAYandexAds setUserConsent: hasUserConsent.boolValue];
     }
 }
 
-- (YMAMutableAdRequest *)createAdRequestWithParameters:(id<MAAdapterResponseParameters>)parameters
+- (YMAAdRequest *)createAdRequestForPlacementId:(NSString *)placementId parameters:(id<MAAdapterResponseParameters>)parameters
 {
-    // MAX specific
-    NSDictionary *adRequestParameters = @{@"adapter_network_name" : @"applovin",
-                                          @"adapter_version" : ADAPTER_VERSION,
-                                          @"adapter_network_sdk_version" : ALSdk.version};
-    
-    YMAMutableAdRequest *adRequest = [[YMAMutableAdRequest alloc] init];
-    adRequest.parameters = adRequestParameters;
-    
-    adRequest.biddingData = parameters.bidResponse;
-    
-    return adRequest;
-}
-
-- (YMAMutableAdRequestConfiguration *)createAdRequestConfigurationForPlacementId:(NSString *)placementId parameters:(id<MAAdapterResponseParameters>)parameters
-{
-    NSDictionary *adRequestParameters = @{@"adapter_network_name" : @"applovin",
-                                          @"adapter_version" : ADAPTER_VERSION,
-                                          @"adapter_network_sdk_version" : ALSdk.version};
-    
-    YMAMutableAdRequestConfiguration *configuration = [[YMAMutableAdRequestConfiguration alloc] initWithAdUnitID: placementId];
-    configuration.parameters = adRequestParameters;
-    
-    configuration.biddingData = parameters.bidResponse;
-    
-    return configuration;
-}
-
-- (YMAMutableNativeAdRequestConfiguration *)createNativeAdRequestConfigurationForPlacementId:(NSString *)placementId parameters:(id<MAAdapterResponseParameters>)parameters
-{
-    NSDictionary *adRequestParameters = @{@"adapter_network_name" : @"applovin",
-                                          @"adapter_version" : ADAPTER_VERSION,
-                                          @"adapter_network_sdk_version" : ALSdk.version};
-    
-    YMAMutableNativeAdRequestConfiguration *configuration = [[YMAMutableNativeAdRequestConfiguration alloc] initWithAdUnitID: placementId];
-    configuration.parameters = adRequestParameters;
-    
-    configuration.biddingData = parameters.bidResponse;
-    
-    return configuration;
+    return [[YMAAdRequest alloc] initWithAdUnitID: placementId
+                                        targeting: nil
+                                          adTheme: YMAAdThemeUnspecified
+                                      biddingData: parameters.bidResponse
+                                headerBiddingData: nil
+                                       parameters: nil];
 }
 
 - (YMABannerAdSize *)yandexAdSizeFromAdFormat:(MAAdFormat *)adFormat
                       isAdaptiveAdViewEnabled:(BOOL)isAdaptiveAdViewEnabled
-                                   parameters:(id<MAAdapterParameters>)parameters
+                                   parameters:(id<MAAdapterResponseParameters>)parameters
 {
     if ( ![adFormat isAdViewAd] )
     {
@@ -426,10 +444,10 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
         return [self adaptiveAdSizeFromParameters: parameters];
     }
     
-    return [YMABannerAdSize fixedSizeWithWidth: adFormat.size.width height: adFormat.size.height];
+    return [YMABannerAdSize fixedWithWidth: adFormat.size.width height: adFormat.size.height];
 }
 
-- (YMABannerAdSize *)adaptiveAdSizeFromParameters:(id<MAAdapterParameters>)parameters
+- (YMABannerAdSize *)adaptiveAdSizeFromParameters:(id<MAAdapterResponseParameters>)parameters
 {
     CGFloat adaptiveAdWidth = [self adaptiveAdViewWidthFromParameters: parameters];
     
@@ -438,72 +456,45 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
         CGFloat inlineMaximumHeight = [self inlineAdaptiveAdViewMaximumHeightFromParameters: parameters];
         if ( inlineMaximumHeight > 0 )
         {
-            return [YMABannerAdSize inlineSizeWithWidth: adaptiveAdWidth maxHeight: inlineMaximumHeight];
+            return [YMABannerAdSize inlineWithWidth: adaptiveAdWidth maxHeight: inlineMaximumHeight];
         }
         
         CGFloat screenHeight = CGRectGetHeight([UIScreen mainScreen].bounds);
-        return [YMABannerAdSize inlineSizeWithWidth: adaptiveAdWidth maxHeight: screenHeight];
+        return [YMABannerAdSize inlineWithWidth: adaptiveAdWidth maxHeight: screenHeight];
     }
     
     // Anchored banners use the default adaptive height
     CGFloat anchoredHeight = [MAAdFormat.banner adaptiveSizeForWidth: adaptiveAdWidth].height;
-    return [YMABannerAdSize fixedSizeWithWidth: adaptiveAdWidth height: anchoredHeight];
+    return [YMABannerAdSize fixedWithWidth: adaptiveAdWidth height: anchoredHeight];
 }
 
-- (YMAAdType)toYandexAdType:(MAAdFormat *)adFormat
+- (YMABidderTokenRequest *)toBidderTokenRequest:(MAAdFormat *)adFormat parameters:(id<MASignalCollectionParameters>)parameters
 {
     if ( adFormat == MAAdFormat.interstitial )
     {
-        return YMAAdTypeInterstitial;
+        return [YMABidderTokenRequest interstitialWithTargeting: nil parameters: nil];
     }
     else if ( adFormat == MAAdFormat.rewarded )
     {
-        return YMAAdTypeRewarded;
+        return [YMABidderTokenRequest rewardedWithTargeting: nil parameters: nil];
     }
     else if ( [adFormat isAdViewAd] )
     {
-        return YMAAdTypeBanner;
+        YMABannerAdSize *adSize = [YMABannerAdSize fixedWithWidth: adFormat.size.width height: adFormat.size.height];
+        return [YMABidderTokenRequest bannerWithSize: adSize targeting: nil parameters: nil];
     }
     else if ( adFormat == MAAdFormat.native )
     {
-        return YMAAdTypeNative;
+        return [YMABidderTokenRequest nativeWithTargeting: nil parameters: nil];
     }
     
-    return -1;
+    return nil;
 }
 
 + (MAAdapterError *)toMaxError:(NSError *)yandexError
 {
-    YMAAdErrorCode yandexErrorCode = yandexError.code;
     MAAdapterError *adapterError = MAAdapterError.unspecified;
-    switch ( yandexErrorCode )
-    {
-        case YMAAdErrorCodeEmptyAdUnitID:
-        case YMAAdErrorCodeInvalidUUID:
-        case YMAAdErrorCodeNoSuchAdUnitID:
-        case YMAAdErrorCodeAdTypeMismatch:
-        case YMAAdErrorCodeAdSizeMismatch:
-        case YMAAdErrorCodeInvalidSDKConfiguration:
-        case YMAAdErrorCodeMissingSKAdNetworkIdentifier:
-            adapterError = MAAdapterError.invalidConfiguration;
-            break;
-        case YMAAdErrorCodeNoFill:
-            adapterError = MAAdapterError.noFill;
-            break;
-        case YMAAdErrorCodeBadServerResponse:
-            adapterError = MAAdapterError.serverError;
-            break;
-        case YMAAdErrorCodeServiceTemporarilyNotAvailable:
-            adapterError = MAAdapterError.timeout;
-            break;
-        case YMAAdErrorCodeAdHasAlreadyBeenPresented:
-            adapterError = MAAdapterError.invalidLoadState;
-            break;
-        case YMAAdErrorCodeNilPresentingViewController:
-        case YMAAdErrorCodeIncorrectFullscreenView:
-            adapterError = MAAdapterError.internalError;
-            break;
-    }
+    NSInteger yandexErrorCode = yandexError.code;
     
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -532,23 +523,6 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     return self;
 }
 
-- (void)interstitialAdLoader:(YMAInterstitialAdLoader *)adLoader didLoad:(YMAInterstitialAd *)interstitialAd
-{
-    [self.parentAdapter log: @"Interstitial ad loaded"];
-    self.parentAdapter.interstitialAd = interstitialAd;
-    interstitialAd.delegate = self.parentAdapter.interstitialAdapterDelegate;
-    [self.delegate didLoadInterstitialAd];
-}
-
-- (void)interstitialAdLoader:(YMAInterstitialAdLoader *)adLoader didFailToLoadWithError:(YMAAdRequestError *)yandexError
-{
-    NSError *error = yandexError.error;
-    [self.parentAdapter log: @"Interstitial ad failed to load with error code %ld and description: %@", error.code, error.description];
-    
-    MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-    [self.delegate didFailToLoadInterstitialAdWithError: adapterError];
-}
-
 - (void)interstitialAdDidShow:(YMAInterstitialAd *)interstitialAd
 {
     [self.parentAdapter log: @"Interstitial ad shown"];
@@ -568,7 +542,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     [self.delegate didDisplayInterstitialAd];
 }
 
-- (void)interstitialAd:(YMAInterstitialAd *)interstitialAd didFailToShowWithError:(NSError *)error
+- (void)interstitialAd:(YMAInterstitialAd *)interstitialAd didFailToShow:(NSError *)error
 {
     MAAdapterError *adapterError = [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
                                                 mediatedNetworkErrorCode: error.code
@@ -608,23 +582,6 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     return self;
 }
 
-- (void)rewardedAdLoader:(YMARewardedAdLoader *)adLoader didLoad:(YMARewardedAd *)rewardedAd
-{
-    [self.parentAdapter log: @"Rewarded ad loaded"];
-    self.parentAdapter.rewardedAd = rewardedAd;
-    rewardedAd.delegate = self.parentAdapter.rewardedAdapterDelegate;
-    [self.delegate didLoadRewardedAd];
-}
-
-- (void)rewardedAdLoader:(YMARewardedAdLoader *)adLoader didFailToLoadWithError:(YMAAdRequestError *)yandexError
-{
-    NSError *error = yandexError.error;
-    [self.parentAdapter log: @"Rewarded ad failed to load with error code %ld and description: %@", error.code, error.description];
-    
-    MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-    [self.delegate didFailToLoadRewardedAdWithError: adapterError];
-}
-
 - (void)rewardedAdDidShow:(YMARewardedAd *)rewardedAd
 {
     [self.parentAdapter log: @"Rewarded ad shown"];
@@ -638,13 +595,13 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
 
 // Note: This method is generally called with a 3 second delay after the ad has been displayed.
 //       This method is not called for test mode ads.
-- (void)rewardedAd:(YMARewardedAd *)rewardedAd didTrackImpressionWith:(id<YMAImpressionData>)impressionData
+- (void)rewardedAd:(YMARewardedAd *)rewardedAd didTrackImpressionWithData:(nullable id<YMAImpressionData>)impressionData
 {
     [self.parentAdapter log: @"Rewarded ad impression tracked"];
     [self.delegate didDisplayRewardedAd];
 }
 
-- (void)rewardedAd:(YMARewardedAd *)rewardedAd didFailToShowWithError:(NSError *)error
+- (void)rewardedAd:(YMARewardedAd *)rewardedAd didFailToShow:(NSError *)error
 {
     MAAdapterError *adapterError = [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
                                                 mediatedNetworkErrorCode: error.code
@@ -700,20 +657,20 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     return self;
 }
 
-- (void)adViewDidLoad:(YMAAdView *)adView
+- (void)bannerAdViewDidLoad:(YMABannerAdView *)bannerAdView
 {
     [self.parentAdapter log: @"%@ ad loaded", self.adFormatLabel];
     
     NSMutableDictionary *extraInfo = [NSMutableDictionary dictionaryWithCapacity: 2];
     
-    CGSize adSize = [adView adContentSize];
+    CGSize adSize = [bannerAdView adContentSize];
     extraInfo[@"ad_width"] = @(adSize.width);
     extraInfo[@"ad_height"] = @(adSize.height);
     
-    [self.delegate didLoadAdForAdView: adView withExtraInfo: extraInfo];
+    [self.delegate didLoadAdForAdView: bannerAdView withExtraInfo: extraInfo];
 }
 
-- (void)adViewDidFailLoading:(YMAAdView *)adView error:(NSError *)error
+- (void)bannerAdViewDidFailLoading:(YMABannerAdView *)bannerAdView error:(NSError *)error
 {
     [self.parentAdapter log: @"%@ ad failed to display with error code %ld and description: %@", self.adFormatLabel, error.code, error.description];
     
@@ -721,34 +678,13 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     [self.delegate didFailToLoadAdViewAdWithError: adapterError];
 }
 
-- (void)adViewDidClick:(YMAAdView *)adView
+- (void)bannerAdViewDidClick:(YMABannerAdView *)bannerAdView
 {
     [self.parentAdapter log: @"%@ ad clicked", self.adFormatLabel];
     [self.delegate didClickAdViewAd];
 }
 
-- (void)adView:(YMAAdView *)adView willPresentScreen:(nullable UIViewController *)viewController
-{
-    // This callback and adViewWillLeaveApplication are mutually exclusive
-    // Ad either opens in-app or redirects to another app
-    [self.parentAdapter log: @"%@ ad clicked and in-app browser opened", self.adFormatLabel];
-    [self.delegate didExpandAdViewAd];
-}
-
-- (void)adViewWillLeaveApplication:(YMAAdView *)adView
-{
-    // This callback and adViewWillPresentScreen are mutually exclusive
-    // Ad either opens in-app or redirects to another app
-    [self.parentAdapter log: @"%@ ad clicked and left application", self.adFormatLabel];
-}
-
-- (void)adView:(YMAAdView *)adView didDismissScreen:(nullable UIViewController *)viewController
-{
-    [self.parentAdapter log: @"%@ ad in-app browser closed", self.adFormatLabel];
-    [self.delegate didCollapseAdViewAd];
-}
-
-- (void)adView:(YMAAdView *)adView didTrackImpressionWithData:(nullable id<YMAImpressionData>)impressionData
+- (void)bannerAdView:(YMABannerAdView *)bannerAdView didTrackImpressionWithData:(nullable id<YMAImpressionData>)impressionData
 {
     [self.parentAdapter log: @"AdView ad impression tracked"];
     [self.delegate didDisplayAdViewAd];
@@ -774,42 +710,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     return self;
 }
 
-- (void)nativeAdLoader:(YMANativeAdLoader *)loader didFailLoadingWithError:(NSError *)error
-{
-    [self.parentAdapter log: @"Native ad failed to load with error code %ld and description: %@", error.code, error.description];
-    
-    MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-    [self.delegate didFailToLoadNativeAdWithError: adapterError];
-}
-
-- (void)nativeAdLoader:(YMANativeAdLoader *)loader didLoadAd:(id<YMANativeAd>)ad
-{
-    [self.parentAdapter log: @"Native ad loaded"];
-    self.parentAdapter.nativeAd = ad;
-    ad.delegate = self.parentAdapter.nativeAdapterDelegate;
-    YMANativeAdAssets *assets = ad.adAssets;
-    MANativeAd *maxNativeAd = [[MAYandexNativeAd alloc] initWithParentAdapter: self.parentAdapter builderBlock:^(MANativeAdBuilder *builder) {
-        builder.title = assets.title;
-        builder.advertiser = assets.domain;
-        builder.body = assets.body;
-        builder.callToAction = assets.callToAction;
-        builder.icon = [[MANativeAdImage alloc] initWithImage: assets.icon.imageValue];
-        builder.mainImage = [[MANativeAdImage alloc] initWithImage: assets.image.imageValue];
-        builder.optionsView = [[UIButton alloc] init];
-        builder.mediaView = [[YMANativeMediaView alloc] init];
-        builder.mediaContentAspectRatio = assets.media.aspectRatio;
-        builder.starRating = assets.rating;
-    }];
-    
-    [self.delegate didLoadAdForNativeAd: maxNativeAd withExtraInfo: nil];
-}
-
-- (void)nativeAd:(id<YMANativeAd>)ad willPresentScreen:(UIViewController *)viewController
-{
-    [self.parentAdapter log: @"Native ad clicked and in-app browser opened"];
-}
-
-- (void)nativeAd:(id<YMANativeAd>)ad didTrackImpressionWithData:(id<YMAImpressionData>)impressionData
+- (void)nativeAd:(id<YMANativeAd>)ad didTrackImpressionWithData:(nullable id<YMAImpressionData>)impressionData
 {
     [self.parentAdapter log: @"Native ad impression tracked"];
     [self.delegate didDisplayNativeAdWithExtraInfo: nil];
@@ -819,21 +720,6 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
 {
     [self.parentAdapter log: @"Native ad clicked"];
     [self.delegate didClickNativeAd];
-}
-
-- (void)nativeAdWillLeaveApplication:(id<YMANativeAd>)ad
-{
-    [self.parentAdapter log: @"Native ad clicked and left application"];
-}
-
-- (void)nativeAd:(id<YMANativeAd>)ad didDismissScreen:(UIViewController *)viewController
-{
-    [self.parentAdapter log: @"Native ad in-app browser closed"];
-}
-
-- (void)closeNativeAd:(id<YMANativeAd>)ad
-{
-    [self.parentAdapter log: @"Native ad closed"];
 }
 
 @end

--- a/Yandex/YandexAdapter/ALYandexMediationAdapter.m
+++ b/Yandex/YandexAdapter/ALYandexMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALYandexMediationAdapter.h"
 #import <YandexMobileAds/YandexMobileAds.h>
 
-#define ADAPTER_VERSION @"8.0.0.0-beta"
+#define ADAPTER_VERSION @"8.0.0-beta.1"
 
 #define TITLE_LABEL_TAG          1
 #define MEDIA_VIEW_CONTAINER_TAG 2
@@ -42,6 +42,19 @@
 @property (nonatomic, assign, getter=hasGrantedReward) BOOL grantedReward;
 
 - (instancetype)initWithParentAdapter:(ALYandexMediationAdapter *)parentAdapter withParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate;
+
+@end
+
+/**
+ * Dedicated delegate object for Yandex app open ads.
+ */
+@interface ALYandexMediationAdapterAppOpenAdDelegate : NSObject <YMAAppOpenAdDelegate>
+
+@property (nonatomic,   weak) ALYandexMediationAdapter *parentAdapter;
+@property (nonatomic, strong) id<MAAdapterResponseParameters> parameters;
+@property (nonatomic, strong) id<MAAppOpenAdapterDelegate> delegate;
+
+- (instancetype)initWithParentAdapter:(ALYandexMediationAdapter *)parentAdapter withParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate;
 
 @end
 
@@ -96,6 +109,11 @@
 @property (nonatomic, strong) YMARewardedAd *rewardedAd;
 @property (nonatomic, strong) ALYandexMediationAdapterRewardedAdDelegate *rewardedAdapterDelegate;
 @property (nonatomic, strong) YMARewardedAdLoader *rewardedAdLoader;
+
+// App Open
+@property (nonatomic, strong) YMAAppOpenAd *appOpenAd;
+@property (nonatomic, strong) ALYandexMediationAdapterAppOpenAdDelegate *appOpenAdapterDelegate;
+@property (nonatomic, strong) YMAAppOpenAdLoader *appOpenAdLoader;
 
 // AdView
 @property (nonatomic, strong) YMABannerAdView *adView;
@@ -164,6 +182,12 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     self.rewardedAdapterDelegate = nil;
     self.rewardedAdLoader = nil;
     
+    self.appOpenAd.delegate = nil;
+    self.appOpenAd = nil;
+    self.appOpenAdapterDelegate.delegate = nil;
+    self.appOpenAdapterDelegate = nil;
+    self.appOpenAdLoader = nil;
+    
     self.adView.delegate = nil;
     self.adView = nil;
     self.adViewAdapterDelegate.delegate = nil;
@@ -215,21 +239,26 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     
     __weak typeof(self) weakSelf = self;
     [self.interstitialAdLoader loadAdWith: adRequest completionHandler:^(YMAInterstitialAd * _Nullable interstitialAd, NSError * _Nullable error) {
-        __strong typeof(self) strongSelf = weakSelf;
-        if ( !strongSelf ) return;
-        
-        if ( error )
-        {
-            [strongSelf log: @"Interstitial ad failed to load with error code %ld and description: %@", error.code, error.description];
-            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-            [strongSelf.interstitialAdapterDelegate.delegate didFailToLoadInterstitialAdWithError: adapterError];
-            return;
-        }
-        
-        [strongSelf log: @"Interstitial ad loaded"];
-        strongSelf.interstitialAd = interstitialAd;
-        interstitialAd.delegate = strongSelf.interstitialAdapterDelegate;
-        [strongSelf.interstitialAdapterDelegate.delegate didLoadInterstitialAd];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(self) strongSelf = weakSelf;
+            if ( !strongSelf )
+            {
+                return;
+            }
+            
+            if ( error )
+            {
+                [strongSelf log: @"Interstitial ad failed to load with error code %ld and description: %@", error.code, error.description];
+                MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+                [strongSelf.interstitialAdapterDelegate.delegate didFailToLoadInterstitialAdWithError: adapterError];
+                return;
+            }
+            
+            [strongSelf log: @"Interstitial ad loaded"];
+            strongSelf.interstitialAd = interstitialAd;
+            interstitialAd.delegate = strongSelf.interstitialAdapterDelegate;
+            [strongSelf.interstitialAdapterDelegate.delegate didLoadInterstitialAd];
+        });
     }];
 }
 
@@ -279,21 +308,27 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     
     __weak typeof(self) weakSelf = self;
     [self.rewardedAdLoader loadAdWith: adRequest completionHandler:^(YMARewardedAd * _Nullable rewardedAd, NSError * _Nullable error) {
-        __strong typeof(self) strongSelf = weakSelf;
-        if ( !strongSelf ) return;
-        
-        if ( error )
-        {
-            [strongSelf log: @"Rewarded ad failed to load with error code %ld and description: %@", error.code, error.description];
-            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-            [strongSelf.rewardedAdapterDelegate.delegate didFailToLoadRewardedAdWithError: adapterError];
-            return;
-        }
-        
-        [strongSelf log: @"Rewarded ad loaded"];
-        strongSelf.rewardedAd = rewardedAd;
-        rewardedAd.delegate = strongSelf.rewardedAdapterDelegate;
-        [strongSelf.rewardedAdapterDelegate.delegate didLoadRewardedAd];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(self) strongSelf = weakSelf;
+            if ( !strongSelf )
+            {
+                return;
+            }
+            
+            if ( error )
+            {
+                [strongSelf log: @"Rewarded ad failed to load with error code %ld and description: %@", error.code, error.description];
+                MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+                [strongSelf.rewardedAdapterDelegate.delegate didFailToLoadRewardedAdWithError: adapterError];
+                
+                return;
+            }
+            
+            [strongSelf log: @"Rewarded ad loaded"];
+            strongSelf.rewardedAd = rewardedAd;
+            rewardedAd.delegate = strongSelf.rewardedAdapterDelegate;
+            [strongSelf.rewardedAdapterDelegate.delegate didLoadRewardedAd];
+        });
     }];
 }
 
@@ -326,6 +361,76 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     }
     
     [self.rewardedAd showFromViewController: presentingViewController];
+}
+
+#pragma mark - MAAppOpenAdapter Methods
+
+- (void)loadAppOpenAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
+{
+    NSString *placementId = parameters.thirdPartyAdPlacementIdentifier;
+    [self log: @"Loading %@app open ad for placement id: %@...", ( [parameters.bidResponse al_isValidString] ? @"bidding " : @"" ), placementId];
+
+    [self updateUserConsent: parameters];
+
+    self.appOpenAdLoader = [[YMAAppOpenAdLoader alloc] init];
+    self.appOpenAdapterDelegate = [[ALYandexMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self
+                                                                                            withParameters: parameters
+                                                                                                 andNotify: delegate];
+
+    YMAAdRequest *adRequest = [self createAdRequestForPlacementId: placementId parameters: parameters];
+    
+    __weak typeof(self) weakSelf = self;
+    [self.appOpenAdLoader loadAdWith: adRequest completionHandler:^(YMAAppOpenAd * _Nullable appOpenAd, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(self) strongSelf = weakSelf;
+            if ( !strongSelf )
+            {
+                return;
+            }
+            
+            if ( error )
+            {
+                [strongSelf log: @"App open ad failed to load with error code %ld and description: %@", error.code, error.description];
+                MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+                [strongSelf.appOpenAdapterDelegate.delegate didFailToLoadAppOpenAdWithError: adapterError];
+                
+                return;
+            }
+            
+            [strongSelf log: @"App open ad loaded"];
+            strongSelf.appOpenAd = appOpenAd;
+            appOpenAd.delegate = strongSelf.appOpenAdapterDelegate;
+            [strongSelf.appOpenAdapterDelegate.delegate didLoadAppOpenAd];
+        });
+    }];
+}
+
+- (void)showAppOpenAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
+{
+    [self log: @"Showing app open ad..."];
+
+    if ( !self.appOpenAd )
+    {
+        [self log: @"App open ad failed to show - ad not ready"];
+
+        [delegate didFailToDisplayAppOpenAdWithError: [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
+                                                                    mediatedNetworkErrorCode: MAAdapterError.adNotReady.code
+                                                                 mediatedNetworkErrorMessage: MAAdapterError.adNotReady.message]];
+
+        return;
+    }
+
+    UIViewController *presentingViewController;
+    if ( ALSdk.versionCode >= 11020199 )
+    {
+        presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
+    }
+    else
+    {
+        presentingViewController = [ALUtils topViewControllerFromKeyWindow];
+    }
+
+    [self.appOpenAd showFromViewController: presentingViewController];
 }
 
 #pragma mark - MAAdViewAdapter Methods
@@ -377,35 +482,41 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     
     __weak typeof(self) weakSelf = self;
     [self.nativeAdLoader loadAdWith: adRequest options: [[YMANativeAdOptions alloc] initWithShouldLoadImagesAutomatically:YES] completionHandler:^(id<YMANativeAd> _Nullable nativeAd, NSError * _Nullable error) {
-        __strong typeof(self) strongSelf = weakSelf;
-        if ( !strongSelf ) return;
-        
-        if ( error )
-        {
-            [strongSelf log: @"Native ad failed to load with error code %ld and description: %@", error.code, error.description];
-            MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
-            [strongSelf.nativeAdapterDelegate.delegate didFailToLoadNativeAdWithError: adapterError];
-            return;
-        }
-        
-        [strongSelf log: @"Native ad loaded"];
-        strongSelf.nativeAd = nativeAd;
-        nativeAd.delegate = strongSelf.nativeAdapterDelegate;
-        YMANativeAdAssets *assets = [nativeAd adAssets];
-        MANativeAd *maxNativeAd = [[MAYandexNativeAd alloc] initWithParentAdapter: strongSelf builderBlock:^(MANativeAdBuilder *builder) {
-            builder.title = assets.title;
-            builder.advertiser = assets.domain;
-            builder.body = assets.body;
-            builder.callToAction = assets.callToAction;
-            builder.icon = [[MANativeAdImage alloc] initWithImage: assets.icon.imageValue];
-            builder.mainImage = [[MANativeAdImage alloc] initWithImage: assets.image.imageValue];
-            builder.optionsView = [[UIButton alloc] init];
-            builder.mediaView = [[YMANativeMediaView alloc] init];
-            builder.mediaContentAspectRatio = assets.media.aspectRatio;
-            builder.starRating = assets.rating;
-        }];
-        
-        [strongSelf.nativeAdapterDelegate.delegate didLoadAdForNativeAd: maxNativeAd withExtraInfo: nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(self) strongSelf = weakSelf;
+            if ( !strongSelf )
+            {
+                return;
+            }
+            
+            if ( error )
+            {
+                [strongSelf log: @"Native ad failed to load with error code %ld and description: %@", error.code, error.description];
+                MAAdapterError *adapterError = [ALYandexMediationAdapter toMaxError: error];
+                [strongSelf.nativeAdapterDelegate.delegate didFailToLoadNativeAdWithError: adapterError];
+                
+                return;
+            }
+            
+            [strongSelf log: @"Native ad loaded"];
+            strongSelf.nativeAd = nativeAd;
+            nativeAd.delegate = strongSelf.nativeAdapterDelegate;
+            YMANativeAdAssets *assets = [nativeAd adAssets];
+            MANativeAd *maxNativeAd = [[MAYandexNativeAd alloc] initWithParentAdapter: strongSelf builderBlock:^(MANativeAdBuilder *builder) {
+                builder.title = assets.title;
+                builder.advertiser = assets.domain;
+                builder.body = assets.body;
+                builder.callToAction = assets.callToAction;
+                builder.icon = [[MANativeAdImage alloc] initWithImage: assets.icon.imageValue];
+                builder.mainImage = [[MANativeAdImage alloc] initWithImage: assets.image.imageValue];
+                builder.optionsView = [[UIButton alloc] init];
+                builder.mediaView = [[YMANativeMediaView alloc] init];
+                builder.mediaContentAspectRatio = assets.media.aspectRatio;
+                builder.starRating = assets.rating;
+            }];
+            
+            [strongSelf.nativeAdapterDelegate.delegate didLoadAdForNativeAd: maxNativeAd withExtraInfo: nil];
+        });
     }];
 }
 
@@ -477,6 +588,10 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     else if ( adFormat == MAAdFormat.rewarded )
     {
         return [YMABidderTokenRequest rewardedWithTargeting: nil parameters: nil];
+    }
+    else if ( adFormat == MAAdFormat.appOpen )
+    {
+        return [YMABidderTokenRequest appOpenAdWithTargeting: nil parameters: nil];
     }
     else if ( [adFormat isAdViewAd] )
     {
@@ -635,6 +750,66 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     }
     
     [self.delegate didHideRewardedAd];
+}
+
+@end
+
+#pragma mark - ALYandexMediationAdapterAppOpenAdDelegate
+
+@implementation ALYandexMediationAdapterAppOpenAdDelegate
+
+- (instancetype)initWithParentAdapter:(ALYandexMediationAdapter *)parentAdapter withParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
+{
+    self = [super init];
+    if ( self )
+    {
+        self.parameters = parameters;
+        self.parentAdapter = parentAdapter;
+        self.delegate = delegate;
+    }
+    return self;
+}
+
+
+- (void)appOpenAdDidShow:(YMAAppOpenAd *)appOpenAd
+{
+    [self.parentAdapter log: @"App open ad shown"];
+
+    // Fire callbacks here for test mode ads since onAdapterImpressionTracked() doesn't get called for them
+    if ( [self.parameters isTesting] )
+    {
+        [self.delegate didDisplayAppOpenAd];
+    }
+}
+
+// Note: This method is generally called with a 3 second delay after the ad has been displayed.
+//       This method is not called for test mode ads.
+- (void)appOpenAd:(YMAAppOpenAd *)appOpenAd didTrackImpressionWithData:(nullable id<YMAImpressionData>)impressionData
+{
+    [self.parentAdapter log: @"App open ad impression tracked"];
+    [self.delegate didDisplayAppOpenAd];
+}
+
+- (void)appOpenAd:(YMAAppOpenAd *)appOpenAd didFailToShowWithError:(NSError *)error
+{
+    MAAdapterError *adapterError = [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
+                                                mediatedNetworkErrorCode: error.code
+                                             mediatedNetworkErrorMessage: error.localizedDescription];
+
+    [self.parentAdapter log: @"App open ad failed to display with error: %@", adapterError];
+    [self.delegate didFailToDisplayAppOpenAdWithError: adapterError];
+}
+
+- (void)appOpenAdDidClick:(YMAAppOpenAd *)appOpenAd
+{
+    [self.parentAdapter log: @"App open ad clicked"];
+    [self.delegate didClickAppOpenAd];
+}
+
+- (void)appOpenAdDidDismiss:(YMAAppOpenAd *)appOpenAd
+{
+    [self.parentAdapter log: @"App open ad hidden"];
+    [self.delegate didHideAppOpenAd];
 }
 
 @end

--- a/Yandex/YandexAdapter/ALYandexMediationAdapter.m
+++ b/Yandex/YandexAdapter/ALYandexMediationAdapter.m
@@ -542,7 +542,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     [self.delegate didDisplayInterstitialAd];
 }
 
-- (void)interstitialAd:(YMAInterstitialAd *)interstitialAd didFailToShow:(NSError *)error
+- (void)interstitialAd:(YMAInterstitialAd *)interstitialAd didFailToShowWithError:(NSError *)error
 {
     MAAdapterError *adapterError = [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
                                                 mediatedNetworkErrorCode: error.code
@@ -601,7 +601,7 @@ static YMABidderTokenLoader *ALYandexBidderTokenLoader;
     [self.delegate didDisplayRewardedAd];
 }
 
-- (void)rewardedAd:(YMARewardedAd *)rewardedAd didFailToShow:(NSError *)error
+- (void)rewardedAd:(YMARewardedAd *)rewardedAd didFailToShowWithError:(NSError *)error
 {
     MAAdapterError *adapterError = [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
                                                 mediatedNetworkErrorCode: error.code

--- a/Yandex/YandexAdapter/ALYandexMediationAdapter.m
+++ b/Yandex/YandexAdapter/ALYandexMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALYandexMediationAdapter.h"
 #import <YandexMobileAds/YandexMobileAds.h>
 
-#define ADAPTER_VERSION @"8.0.0-beta.1"
+#define ADAPTER_VERSION @"8.0.0"
 
 #define TITLE_LABEL_TAG          1
 #define MEDIA_VIEW_CONTAINER_TAG 2


### PR DESCRIPTION
###  Updated adapter to version to Yandex SDK **8.0.0-beta.1**
• **_Async loading pattern_**: replaced loader delegates with completion handlers for interstitial, rewarded, and native ads
• **_API renaming_**: `YMAMobileAds` → `YMAYandexAds`, `YMAAdView` → `YMABannerAdView`, updated delegate method names
• **_Unified requests_**: Single `YMAAdRequest` class replaces separate configuration classes for each ad type
• **_Adapter identity_**: Added `YMAAdapterIdentity` initialization to identify AppLovin adapter
• **_Simplified callbacks_**: Removed deprecated screen presentation methods, updated impression tracking signatures to nullable
### App Open Ads Support
• Implemented `MAAppOpenAdapter` protocol with full load/show functionality
### Migration guide
• For a full migration guide see [Yandex migration documentation](https://ads.yandex.com/helpcenter/en/dev/ios/release/8-0-0-migration)
### SDK version
• Update Yandex Mobile Ads SDK dependency to `8.0.0`