### PR TITLE
[Moloco] Add adaptive banner support

### DIFF
--- a/Moloco/AppLovinMediationMolocoAdapter.podspec
+++ b/Moloco/AppLovinMediationMolocoAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationMolocoAdapter'
-s.version = '4.8.0.0'
+s.version = '4.8.0.1'
 s.platform = :ios, '12.0' # Note: Minimum iOS version set to 12.0 to allow publishers to integrate without increasing their minimum version requirement. Ads will serve on iOS 13.0+.
 s.summary = 'Moloco adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/Moloco/CHANGELOG.md
+++ b/Moloco/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.8.0.1
+* Add support for adaptive banner ads.
+
 ## 4.8.0.0
 * Certified with Moloco SDK 4.8.0.
 

--- a/Moloco/MolocoAdapter/MolocoAdapter+AdView.swift
+++ b/Moloco/MolocoAdapter/MolocoAdapter+AdView.swift
@@ -48,21 +48,15 @@ extension MolocoAdapter: MAAdViewAdapter
         else
         {
             Task {
-                let viewController = await MainActor.run {
-                    presentingViewController(for: parameters)
+                let (viewController, size) = await MainActor.run { () -> (UIViewController, MolocoBannerAdSize) in
+                    let viewController = presentingViewController(for: parameters)
+                    let size = molocoBannerAdSize(for: adFormat, parameters: parameters, presentingViewController: viewController)
+                    return (viewController, size)
                 }
-                
+
                 adViewDelegate = .init(adapter: self, delegate: delegate, adFormat: adFormat, parameters: parameters)
-                
-                switch adFormat
-                {
-                case .banner, .leader:
-                    adView = await Moloco.shared.createBanner(params: .init(adUnit: placementId, mediation: "max"), viewController: viewController)
-                case .mrec:
-                    adView = await Moloco.shared.createMREC(params: .init(adUnit: placementId, mediation: "max"), viewController: viewController)
-                default:
-                    break
-                }
+
+                adView = await Moloco.shared.createMolocoBanner(params: .init(adUnit: placementId, mediation: "max"), size: size, viewController: viewController)
                 
                 guard let adView else
                 {
@@ -78,6 +72,81 @@ extension MolocoAdapter: MAAdViewAdapter
                 await adView.load(bidResponse: parameters.bidResponse)
             }
         }
+    }
+}
+
+@available(iOS 13.0, *)
+extension MolocoAdapter
+{
+    @MainActor
+    func molocoBannerAdSize(for adFormat: MAAdFormat,
+                            parameters: MAAdapterResponseParameters,
+                            presentingViewController: UIViewController) -> MolocoBannerAdSize
+    {
+        let isAdaptiveBanner = boolValue(adaptiveParameter("adaptive_banner", from: parameters))
+        if isAdaptiveBanner, isAdaptiveAdViewFormat(adFormat, parameters: parameters)
+        {
+            let width = adaptiveBannerWidth(from: parameters, presentingViewController: presentingViewController)
+            return isInlineAdaptiveBanner(parameters)
+                ? .inlineAdaptive(width: Int(width))
+                : .anchoredAdaptive(width: Int(width))
+        }
+
+        switch adFormat
+        {
+        case .banner, .leader:
+            return .standard
+        case .mrec:
+            return .mrec
+        default:
+            return .standard
+        }
+    }
+
+    // Adaptive banners must be inline for MRECs.
+    private func isAdaptiveAdViewFormat(_ adFormat: MAAdFormat, parameters: MAAdapterResponseParameters) -> Bool
+    {
+        if adFormat == MAAdFormat.mrec
+        {
+            return isInlineAdaptiveBanner(parameters)
+        }
+        return adFormat == MAAdFormat.banner || adFormat == MAAdFormat.leader
+    }
+
+    private func isInlineAdaptiveBanner(_ parameters: MAAdapterResponseParameters) -> Bool
+    {
+        guard let type = adaptiveParameter("adaptive_banner_type", from: parameters) as? String else { return false }
+        return type.caseInsensitiveCompare("inline") == .orderedSame
+    }
+
+    @MainActor
+    private func adaptiveBannerWidth(from parameters: MAAdapterResponseParameters,
+                                     presentingViewController: UIViewController) -> CGFloat
+    {
+        if let customWidth = adaptiveParameter("adaptive_banner_width", from: parameters) as? NSNumber
+        {
+            return CGFloat(customWidth.doubleValue)
+        }
+        if let window = presentingViewController.view.window
+        {
+            return window.frame.inset(by: window.safeAreaInsets).width
+        }
+        return UIScreen.main.bounds.width
+    }
+
+    // Adaptive params arrive via serverParameters (server-enabled networks) or
+    // localExtraParameters (client MAAdViewConfiguration). Read both.
+    private func adaptiveParameter(_ key: String, from parameters: MAAdapterResponseParameters) -> Any?
+    {
+        parameters.localExtraParameters[key] ?? parameters.serverParameters[key]
+    }
+
+    private func boolValue(_ value: Any?) -> Bool
+    {
+        if let value = value as? Bool { return value }
+        if let value = value as? NSNumber { return value.boolValue }
+        if let value = value as? String { return (value as NSString).boolValue }
+        return false
     }
 }
 

--- a/Moloco/MolocoAdapter/MolocoAdapter+AdView.swift
+++ b/Moloco/MolocoAdapter/MolocoAdapter+AdView.swift
@@ -123,9 +123,9 @@ extension MolocoAdapter
     private func adaptiveBannerWidth(from parameters: MAAdapterResponseParameters,
                                      presentingViewController: UIViewController) -> CGFloat
     {
-        if let customWidth = adaptiveParameter("adaptive_banner_width", from: parameters) as? NSNumber
+        if let customWidth = doubleValue(adaptiveParameter("adaptive_banner_width", from: parameters))
         {
-            return CGFloat(customWidth.doubleValue)
+            return CGFloat(customWidth)
         }
         if let window = presentingViewController.view.window
         {
@@ -139,6 +139,13 @@ extension MolocoAdapter
     private func adaptiveParameter(_ key: String, from parameters: MAAdapterResponseParameters) -> Any?
     {
         parameters.localExtraParameters[key] ?? parameters.serverParameters[key]
+    }
+
+    private func doubleValue(_ value: Any?) -> Double?
+    {
+        if let value = value as? NSNumber { return value.doubleValue }
+        if let value = value as? String { return Double(value) }
+        return nil
     }
 
     private func boolValue(_ value: Any?) -> Bool


### PR DESCRIPTION
## Summary
Adds **adaptive banner** support to the Moloco MAX adapter, alongside the existing fixed Standard / MREC sizes. Moloco SDK 4.8.0 (already certified in 4.8.0.0) introduced the adaptive banner API; this wires it into the adapter.

## Changes (`MolocoAdapter+AdView.swift`)
- Replace the fixed `createBanner` / `createMREC` branch with the unified `Moloco.shared.createMolocoBanner(params:size:viewController:)`.
- Add `molocoBannerAdSize(for:parameters:presentingViewController:)` that maps the MAX ad format + adaptive parameters to a `MolocoBannerAdSize`:
  - `adaptive_banner` (server param) enables adaptive sizing
  - `adaptive_banner_type` == `inline` → `.inlineAdaptive(width:)`, otherwise `.anchoredAdaptive(width:)`
  - `adaptive_banner_width` (or the safe-area width) sets the width
  - non-adaptive → `.standard` (banner/leader) or `.mrec`

Mirrors the adaptive-banner handling in the **Google** and **ByteDance** MAX adapters in this repo.

## Version
- `4.8.0.1` + CHANGELOG entry. Moloco SDK dependency unchanged (templated `{ADAPTER_SDK_VERSION}`; 4.8.0 already carries the adaptive API).

## Note
Moloco's `inlineAdaptive(width:)` takes only a width (no max-height), so `inline_adaptive_banner_max_height` is not used; inline and anchored render to a width-based adaptive size.