### PR TITLE
[BidMachine] Support publisher-configured placement IDs during signal collection

### DIFF
--- a/BidMachine/AppLovinMediationBidMachineAdapter.podspec
+++ b/BidMachine/AppLovinMediationBidMachineAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationBidMachineAdapter'
-s.version = '3.7.1.0.0'
+s.version = '3.7.1.0.1'
 s.platform = :ios, '12.0'
 s.summary = 'BidMachine adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
+++ b/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALBidMachineMediationAdapter.h"
 #import <BidMachine/BidMachine-Swift.h>
 
-#define ADAPTER_VERSION @"3.7.1.0.0"
+#define ADAPTER_VERSION @"3.7.1.0.1"
 
 #define TITLE_LABEL_TAG          1
 #define MEDIA_VIEW_CONTAINER_TAG 2
@@ -170,16 +170,33 @@ static MAAdapterInitializationStatus ALBidMachineSDKInitializationStatus = NSInt
     
     BidMachinePlacementFormat bidMachinePlacementFormat = [self bidMachinePlacementFormatFromAdFormat: parameters.adFormat];
     
+    NSString *placementId = [parameters.serverParameters al_stringForKey: @"placement_id"];
+    if ( ![placementId al_isValidString] )
+    {
+        NSDictionary *placementIds = [parameters.serverParameters al_dictionaryForKey: @"placement_ids"];
+        placementId = [placementIds al_stringForKey: parameters.adUnitIdentifier];
+    }
+    
+    if ( ![placementId al_isValidString] )
+    {
+        [self log: @"No valid placement ID found during signal collection"];
+    }
+    
     NSError *error;
     BidMachinePlacement *placement = [BidMachineSdk.shared placementFrom: bidMachinePlacementFormat
                                                                    error: &error
-                                                                 builder: nil];
-
+                                                                 builder:^(id<BidMachinePlacementBuilderProtocol> builder) {
+        if ( [placementId al_isValidString] )
+        {
+            [builder withPlacementId: placementId];
+        }
+    }];
+    
     if ( !placement || error )
     {
         [self log: @"Signal collection failed while retrieving placement with error: %@", error];
         [delegate didFailToCollectSignalWithErrorMessage: error.localizedDescription];
-        
+
         return;
     }
     

--- a/BidMachine/CHANGELOG.md
+++ b/BidMachine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.7.1.0.1
+* Add support for publisher-configured placement IDs during signal collection.
+
 ## 3.7.1.0.0
 * Certified with BidMachine SDK 3.7.1.
 


### PR DESCRIPTION
Mirrors the placement ID feature shipped for Android in BidMachine/3.3.0.2 

 - Reads placement_id from the server parameters during signal collection (Falls back to the Android-style placement_ids map keyed by ad unit ID)
- The field is optional: absent/empty value keeps current behavior, no errors, nothing added to the request.

- Note: the dashboard placement field is currently exposed for Android only 